### PR TITLE
Add HTTP status and method parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sazparser
 A simple parser for Session Archive Zip (SAZ) files
 
-Written based on http://fiddler.wikidot.com/saz-files 
+Written based on https://web.archive.org/web/20190109000426/http://fiddler.wikidot.com/saz-files 
 
 The purpose is to analysis the result of fiddler (http://www.telerik.com/fiddler) with script.
 


### PR DESCRIPTION
I needed to parse HTTP method and response status code, so I added them.

Header parsing had an issue where header field would be truncated to first colon. For instance, Referer header contains a URL, but `b'Referer: http://www.example.org'.split(b':')[1]` would only be b'http'.

Finally, [http://fiddler.wikidot.com/saz-files](http://fiddler.wikidot.com/saz-files) does not seem to have any info on saz files currently. I replaced the link with the cached version on Web Archive.